### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Open Deep Research
+[![smithery badge](https://smithery.ai/badge/@Ozamatash/deep-research-mcp)](https://smithery.ai/server/@Ozamatash/deep-research-mcp)
 
 An AI-powered research assistant that performs iterative, deep research on any topic by combining search engines, web scraping, and large language models. Available as a Model Context Protocol (MCP) tool for seamless integration with AI agents.
 
@@ -83,6 +84,14 @@ flowchart TB
   - OpenAI API (for o3 mini model)
 
 ## Setup
+
+### Installing via Smithery
+
+To install Open Deep Research for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@Ozamatash/deep-research-mcp):
+
+```bash
+npx -y @smithery/cli install @Ozamatash/deep-research-mcp --client claude
+```
 
 ### Node.js
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - openaiApiKey
+      - firecrawlKey
+    properties:
+      openaiApiKey:
+        type: string
+        description: The API key for accessing OpenAI services.
+      firecrawlKey:
+        type: string
+        description: The API key for accessing Firecrawl services.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['--env-file', '.env.local', 'dist/mcp-server.js'], env: { OPENAI_API_KEY: config.openaiApiKey, FIRECRAWL_KEY: config.firecrawlKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@Ozamatash/deep-research-mcp?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂