### PR TITLE
docs: add CRW as Firecrawl-compatible alternative

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ FIRECRAWL_KEY=   # Your Firecrawl API key (not needed if using local instance)
 
 # Firecrawl Configuration
 FIRECRAWL_CONCURRENCY=2      # Number of concurrent searches (default: 2)
-FIRECRAWL_BASE_URL=        # Local Firecrawl URL (e.g. "http://localhost:3002")
+FIRECRAWL_BASE_URL=        # Local Firecrawl or CRW URL (e.g. "http://localhost:3002" or "https://fastcrw.com")
 
 # OpenAI Configuration
 CONTEXT_SIZE="128000"

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ FIRECRAWL_KEY=   # Your Firecrawl API key (not needed if using local instance)
 
 # Firecrawl Configuration
 FIRECRAWL_CONCURRENCY=2      # Number of concurrent searches (default: 2)
-FIRECRAWL_BASE_URL=        # Local Firecrawl or CRW URL (e.g. "http://localhost:3002" or "https://fastcrw.com")
+FIRECRAWL_BASE_URL=        # Local Firecrawl or CRW URL (e.g. "http://localhost:3002" or "https://fastcrw.com"). Note: FIRECRAWL_KEY is ignored when this is set — authentication is handled by the target server.
 
 # OpenAI Configuration
 CONTEXT_SIZE="128000"

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ FIRECRAWL_BASE_URL="http://localhost:3002"
 2. **Cloud-hosted:** Use the hosted instance at fastcrw.com:
 ```bash
 FIRECRAWL_BASE_URL="https://fastcrw.com"
-FIRECRAWL_KEY="your_crw_api_key"
+# Note: FIRECRAWL_KEY is not used when FIRECRAWL_BASE_URL is set.
+# Authentication is handled by the CRW server's own key mechanism.
 ```
 
 ### Optional: Observability

--- a/README.md
+++ b/README.md
@@ -161,6 +161,28 @@ cd localfirecrawl
 FIRECRAWL_BASE_URL="http://localhost:3002"
 ```
 
+### Using CRW (Firecrawl-Compatible Alternative)
+
+[CRW](https://github.com/nicklitvin/crw) is an open-source, Firecrawl-compatible web scraper that works as a drop-in replacement. You can self-host it or use the hosted version at [fastcrw.com](https://fastcrw.com). No API key is required for self-hosted instances.
+
+1. **Self-hosted:** Run CRW locally (defaults to port 3002):
+```bash
+git clone https://github.com/nicklitvin/crw
+cd crw
+# Follow setup instructions in the CRW README
+```
+
+Then set in `.env.local`:
+```bash
+FIRECRAWL_BASE_URL="http://localhost:3002"
+```
+
+2. **Cloud-hosted:** Use the hosted instance at fastcrw.com:
+```bash
+FIRECRAWL_BASE_URL="https://fastcrw.com"
+FIRECRAWL_KEY="your_crw_api_key"
+```
+
 ### Optional: Observability
 
 Add observability to track research flows, queries, and results using Langfuse:


### PR DESCRIPTION
## Summary

- Document [CRW](https://github.com/nicklitvin/crw) as a drop-in Firecrawl-compatible web scraping backend
- Add setup instructions for both self-hosted (`localhost:3002`) and cloud-hosted (`fastcrw.com`) usage
- Update `.env.example` to mention CRW alongside Firecrawl

CRW is an open-source Firecrawl-compatible scraper — users can point `FIRECRAWL_BASE_URL` at a CRW instance with zero code changes.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `FIRECRAWL_BASE_URL` works with a CRW instance (self-hosted or fastcrw.com)